### PR TITLE
FIX: javascript 경로 문제 해결

### DIFF
--- a/Notes/javascript/hoisting.md
+++ b/Notes/javascript/hoisting.md
@@ -1,6 +1,6 @@
 # 호이스팅(Hoisting)
 
-> [스코프](https://github.com/baeharam/Must-Know-About-Frontend/blob/master/Notes/Javascript/scope.md) 의 개념을 이해하지 못했다면 이해하고 오자.
+> [스코프](https://github.com/baeharam/Must-Know-About-Frontend/blob/master/Notes/javascript/scope.md) 의 개념을 이해하지 못했다면 이해하고 오자.
 
 호이스팅이란 "끌어올린다" 라는 뜻으로 **변수 및 함수 선언문이 스코프 내의 최상단으로 끌어올려지는 현상** 을 말한다. 여기서 주의할 점은 **"선언문"** 이라는 것이며 "대입문"은 끌어올려지지 않는다. 아래 코드를 보자.
 

--- a/Notes/javascript/var-let-const.md
+++ b/Notes/javascript/var-let-const.md
@@ -4,7 +4,7 @@
 
 ## 스코프 규칙
 
-> 스코프의 개념을 모른다면 [스코프](https://github.com/baeharam/Must-Know-About-Frontend/blob/master/Notes/Javascript/scope.md) 를 보고 오자.
+> 스코프의 개념을 모른다면 [스코프](https://github.com/baeharam/Must-Know-About-Frontend/blob/master/Notes/javascript/scope.md) 를 보고 오자.
 
 * var는 함수 스코프를 갖는다.
 * let과 const는 블록 스코프를 갖는다.
@@ -33,7 +33,7 @@ run();
 
 ## 호이스팅
 
-> 호이스팅의 개념을 모른다면 [호이스팅](https://github.com/baeharam/Must-Know-About-Frontend/blob/master/Notes/Javascript/Hoisting.md) 을 보고 오자.
+> 호이스팅의 개념을 모른다면 [호이스팅](https://github.com/baeharam/Must-Know-About-Frontend/blob/master/Notes/javascript/Hoisting.md) 을 보고 오자.
 
 * var는 **함수 스코프의 최상단으로 호이스팅** 되고 선언과 동시에 `undefined` 로 초기화 된다.
 * let과 const는 **블록 스코프의 최상단으로 호이스팅** 되고 선언만 되고 값이 할당되기 전까지 어떤 값으로도 초기화되지 않는다.


### PR DESCRIPTION
- Javascript -> javascript

## 무엇이 잘못되었나요?
문서 내 링크 중 javascript 폴더의 경로가 Javascript로 되어 있어 404error가 뜨는 이슈


## 어떻게 해결하셨나요?
Javascript를 javascript로 변경해주었다


## 리뷰어들이 주의깊게 봤으면 하는 부분이 있으신가요?

